### PR TITLE
Super secure storage services

### DIFF
--- a/app/src/androidTest/java/com/bc/gordiansigner/RxTest.kt
+++ b/app/src/androidTest/java/com/bc/gordiansigner/RxTest.kt
@@ -1,0 +1,14 @@
+package com.bc.gordiansigner
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.bc.gordiansigner.util.RxImmediateSchedulerRule
+import org.junit.Rule
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+abstract class RxTest {
+
+    @JvmField
+    @Rule
+    val rxImmediateSchedulerRule = RxImmediateSchedulerRule()
+}

--- a/app/src/androidTest/java/com/bc/gordiansigner/service/storage/FileStorageTest.kt
+++ b/app/src/androidTest/java/com/bc/gordiansigner/service/storage/FileStorageTest.kt
@@ -2,6 +2,7 @@ package com.bc.gordiansigner.service.storage
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.bc.gordiansigner.RxTest
 import com.bc.gordiansigner.service.storage.file.FileStorageApi
 import com.bc.gordiansigner.service.storage.file.rxCompletable
 import com.bc.gordiansigner.service.storage.file.rxSingle
@@ -11,7 +12,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-class FileStorageTest {
+class FileStorageTest : RxTest() {
 
     private val appContext = InstrumentationRegistry.getInstrumentation().targetContext
 

--- a/app/src/androidTest/java/com/bc/gordiansigner/service/storage/SharePrefTest.kt
+++ b/app/src/androidTest/java/com/bc/gordiansigner/service/storage/SharePrefTest.kt
@@ -7,6 +7,7 @@ import com.bc.gordiansigner.service.storage.sharedpref.rxCompletable
 import com.bc.gordiansigner.service.storage.sharedpref.rxSingle
 import org.junit.Test
 import org.junit.runner.RunWith
+import kotlin.reflect.KClass
 
 @RunWith(AndroidJUnit4::class)
 class SharePrefTest {
@@ -16,19 +17,46 @@ class SharePrefTest {
     @Test
     fun testReadWriteStandardSharedPref() {
         val dataSet =
-            mapOf("key1" to "val", "key2" to " ", "key3" to "valvalvalvalvalvalvalvalvalvalvalval")
+            mapOf<KClass<*>, Map<String, *>>(
+                String::class to mapOf(
+                    "key1" to "val",
+                    "key2" to " ",
+                    "key3" to "valvalvalvalvalvalvalvalvalvalvalval"
+                ),
+                Set::class to mapOf(
+                    "key1" to setOf("1", "2", "3"),
+                    "key2" to setOf("", "    ", "valvalvalvalvalvalvalvalvalvalvalval")
+                )
+            )
 
         for (d in dataSet.entries) {
-            SharedPrefApi(appContext).STANDARD.rxCompletable { pref -> pref.put(d.key, d.value) }
-                .test()
-                .assertComplete()
-                .assertNoErrors()
+            val type = d.key
+            val value = d.value
 
-            SharedPrefApi(appContext).STANDARD.rxSingle { pref -> pref.get(d.key, String::class) }
-                .test()
-                .assertComplete()
-                .assertNoErrors()
-                .assertValue(d.value)
+            for (v in value) {
+                SharedPrefApi(appContext).STANDARD.rxCompletable { pref ->
+                    pref.put(
+                        v.key,
+                        v.value
+                    )
+                }
+                    .test()
+                    .assertComplete()
+                    .assertNoErrors()
+                v
+                SharedPrefApi(appContext).STANDARD.rxSingle { pref ->
+                    pref.get(
+                        v.key,
+                        type
+                    )
+                }
+                    .test()
+                    .assertComplete()
+                    .assertNoErrors()
+                    .assertValue(v.value)
+            }
+
+
         }
     }
 

--- a/app/src/androidTest/java/com/bc/gordiansigner/service/storage/SharePrefTest.kt
+++ b/app/src/androidTest/java/com/bc/gordiansigner/service/storage/SharePrefTest.kt
@@ -2,6 +2,7 @@ package com.bc.gordiansigner.service.storage
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.bc.gordiansigner.RxTest
 import com.bc.gordiansigner.service.storage.sharedpref.SharedPrefApi
 import com.bc.gordiansigner.service.storage.sharedpref.rxCompletable
 import com.bc.gordiansigner.service.storage.sharedpref.rxSingle
@@ -10,7 +11,7 @@ import org.junit.runner.RunWith
 import kotlin.reflect.KClass
 
 @RunWith(AndroidJUnit4::class)
-class SharePrefTest {
+class SharePrefTest : RxTest() {
 
     private val appContext = InstrumentationRegistry.getInstrumentation().targetContext
 

--- a/app/src/androidTest/java/com/bc/gordiansigner/util/RxImmediateSchedulerRule.kt
+++ b/app/src/androidTest/java/com/bc/gordiansigner/util/RxImmediateSchedulerRule.kt
@@ -1,0 +1,46 @@
+package com.bc.gordiansigner.util
+
+import io.reactivex.Scheduler
+import io.reactivex.disposables.Disposable
+import io.reactivex.internal.schedulers.ExecutorScheduler
+import io.reactivex.plugins.RxJavaPlugins
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+import java.util.concurrent.ScheduledThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+
+class RxImmediateSchedulerRule : TestRule {
+
+    private val immediate = object : Scheduler() {
+
+        override fun scheduleDirect(run: Runnable, delay: Long, unit: TimeUnit): Disposable {
+            return super.scheduleDirect(run, 0, unit)
+        }
+
+        override fun createWorker(): Worker {
+            return ExecutorScheduler.ExecutorWorker(object : ScheduledThreadPoolExecutor(1) {
+                override fun execute(command: Runnable?) {
+                    command?.run()
+                }
+            }, true)
+        }
+    }
+
+    override fun apply(base: Statement?, description: Description?): Statement {
+        return object : Statement() {
+            override fun evaluate() {
+                RxJavaPlugins.setInitIoSchedulerHandler { immediate }
+                RxJavaPlugins.setInitComputationSchedulerHandler { immediate }
+                RxJavaPlugins.setInitNewThreadSchedulerHandler { immediate }
+                RxJavaPlugins.setInitSingleSchedulerHandler { immediate }
+
+                try {
+                    base?.evaluate()
+                } finally {
+                    RxJavaPlugins.reset()
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/bc/gordiansigner/helper/KeyStoreHelper.kt
+++ b/app/src/main/java/com/bc/gordiansigner/helper/KeyStoreHelper.kt
@@ -1,0 +1,42 @@
+package com.bc.gordiansigner.helper
+
+import android.content.Context
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import com.bc.gordiansigner.helper.ext.isStrongboxBacked
+import java.security.GeneralSecurityException
+import javax.crypto.KeyGenerator
+
+object KeyStoreHelper {
+
+    @Throws(GeneralSecurityException::class)
+    fun generateKey(keyGenParameterSpec: KeyGenParameterSpec): String {
+        val keyGenerator = KeyGenerator.getInstance(
+            KeyProperties.KEY_ALGORITHM_AES,
+            "AndroidKeyStore"
+        )
+        keyGenerator.init(keyGenParameterSpec)
+        keyGenerator.generateKey()
+        return keyGenParameterSpec.keystoreAlias
+    }
+
+    fun buildSuperSecureMasterKeySpec(
+        context: Context,
+        keyAlias: String,
+        keySize: Int
+    ): KeyGenParameterSpec {
+        val builder = KeyGenParameterSpec.Builder(
+            keyAlias,
+            KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+        )
+            .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+            .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+            .setUserAuthenticationRequired(true)
+            .setUserAuthenticationParameters(60, KeyProperties.AUTH_BIOMETRIC_STRONG)
+            .setKeySize(keySize)
+        if (android.os.Build.VERSION.SDK_INT > android.os.Build.VERSION_CODES.P && context.isStrongboxBacked()) {
+            builder.setIsStrongBoxBacked(true)
+        }
+        return builder.build()
+    }
+}

--- a/app/src/main/java/com/bc/gordiansigner/helper/KeyStoreHelper.kt
+++ b/app/src/main/java/com/bc/gordiansigner/helper/KeyStoreHelper.kt
@@ -34,7 +34,7 @@ object KeyStoreHelper {
             .setUserAuthenticationRequired(true)
             .setUserAuthenticationParameters(60, KeyProperties.AUTH_BIOMETRIC_STRONG)
             .setKeySize(keySize)
-        if (android.os.Build.VERSION.SDK_INT > android.os.Build.VERSION_CODES.P && context.isStrongboxBacked()) {
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P && context.isStrongboxBacked()) {
             builder.setIsStrongBoxBacked(true)
         }
         return builder.build()

--- a/app/src/main/java/com/bc/gordiansigner/helper/ext/ContextExt.kt
+++ b/app/src/main/java/com/bc/gordiansigner/helper/ext/ContextExt.kt
@@ -4,10 +4,13 @@ import android.app.KeyguardManager
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
+import android.content.pm.PackageManager
 import android.net.Uri
+import android.os.Build
 import android.provider.OpenableColumns
 import androidx.annotation.ColorRes
 import androidx.annotation.DimenRes
+import androidx.annotation.RequiresApi
 import androidx.core.content.ContextCompat
 import androidx.core.content.res.ResourcesCompat
 
@@ -82,3 +85,7 @@ fun Context.getFileName(uri: Uri): String {
         cursor.getString(sizeIndex)
     } ?: ""
 }
+
+@RequiresApi(Build.VERSION_CODES.P)
+fun Context.isStrongboxBacked() =
+    packageManager.hasSystemFeature(PackageManager.FEATURE_STRONGBOX_KEYSTORE)

--- a/app/src/main/java/com/bc/gordiansigner/service/WalletService.kt
+++ b/app/src/main/java/com/bc/gordiansigner/service/WalletService.kt
@@ -38,8 +38,8 @@ class WalletService @Inject constructor(
 
     fun getLocalHDKeyXprvs() =
         sharedPrefApi.SECURE.rxSingle { sharedPref ->
-            sharedPref.sharedPreferences.getStringSet(ROOT_XPRV_KEYS, emptySet())
-        }.map { set -> set.map { HDKey(it) } }
+            sharedPref.get(ROOT_XPRV_KEYS, Set::class)
+        }.map { set -> set.map { HDKey(it as String) } }
 
     fun saveHDKeyXprv(hdKey: HDKey) =
         getLocalHDKeyXprvs().map {
@@ -59,10 +59,7 @@ class WalletService @Inject constructor(
 
     private fun saveHDKeyXprvs(keys: Set<HDKey>) =
         sharedPrefApi.SECURE.rxCompletable { sharedPref ->
-            sharedPref.sharedPreferences
-                .edit()
-                .putStringSet(ROOT_XPRV_KEYS, keys.map { it.xprv }.toSet())
-                .apply()
+            sharedPref.put(ROOT_XPRV_KEYS, keys.map { it.xprv }.toSet())
         }
 
     /** END - simple mechanism getting & saving account by storing XPRVS **/

--- a/app/src/main/java/com/bc/gordiansigner/service/storage/file/FileGateway.kt
+++ b/app/src/main/java/com/bc/gordiansigner/service/storage/file/FileGateway.kt
@@ -3,6 +3,7 @@ package com.bc.gordiansigner.service.storage.file
 import android.content.Context
 import io.reactivex.Completable
 import io.reactivex.Single
+import io.reactivex.schedulers.Schedulers
 import java.io.File
 
 abstract class FileGateway(protected val context: Context) {
@@ -32,7 +33,8 @@ abstract class FileGateway(protected val context: Context) {
     fun deleteOnFilesDir(name: String): Boolean = delete(File(context.filesDir, name).absolutePath)
 }
 
-fun <T> FileGateway.rxSingle(action: (FileGateway) -> T) = Single.fromCallable { action(this) }
+fun <T> FileGateway.rxSingle(action: (FileGateway) -> T) =
+    Single.fromCallable { action(this) }.subscribeOn(Schedulers.io())
 
 fun FileGateway.rxCompletable(action: (FileGateway) -> Unit) =
-    Completable.fromCallable { action(this) }
+    Completable.fromCallable { action(this) }.subscribeOn(Schedulers.io())

--- a/app/src/main/java/com/bc/gordiansigner/service/storage/file/FileStorageApi.kt
+++ b/app/src/main/java/com/bc/gordiansigner/service/storage/file/FileStorageApi.kt
@@ -15,4 +15,6 @@ class FileStorageApi @Inject constructor(context: Context) {
 
     val SECURE = lazy { SecureFileGateway(context) }.value
 
+    val SUPER_SECURE = lazy { SuperSecureFileGateway(context) }.value
+
 }

--- a/app/src/main/java/com/bc/gordiansigner/service/storage/file/SecureFileGateway.kt
+++ b/app/src/main/java/com/bc/gordiansigner/service/storage/file/SecureFileGateway.kt
@@ -6,9 +6,13 @@ import androidx.security.crypto.MasterKeys
 import java.io.ByteArrayOutputStream
 import java.io.File
 
-class SecureFileGateway internal constructor(context: Context) : FileGateway(context) {
+/**
+ * This level of security uses Android Keystore system to encrypt/decrypt the file content.
+ * The key never enters to the app process so it's secure even the phone could get hack.
+ */
+open class SecureFileGateway internal constructor(context: Context) : FileGateway(context) {
 
-    private val MASTER_KEY_ALIAS = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC)
+    protected open val MASTER_KEY_ALIAS = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC)
 
     override fun write(path: String, name: String, data: ByteArray) {
         val file = getEncryptedFile("$path/$name")

--- a/app/src/main/java/com/bc/gordiansigner/service/storage/file/SuperSecureFileGateway.kt
+++ b/app/src/main/java/com/bc/gordiansigner/service/storage/file/SuperSecureFileGateway.kt
@@ -1,0 +1,28 @@
+package com.bc.gordiansigner.service.storage.file
+
+import android.content.Context
+import androidx.security.crypto.MasterKeys
+import com.bc.gordiansigner.helper.KeyStoreHelper
+
+/**
+ * This level of security requires user authentication (device biometric) each time using the key.
+ * It also use hardware-backed if API level is 28 or above.
+ * Throws [IllegalStateException] if device biometric auth has not been setup.
+ * Throws [java.security.KeyStoreException] with root cause [android.security.keystore.UserNotAuthenticatedException] if user has not authenticated by biometric.
+ */
+class SuperSecureFileGateway internal constructor(context: Context) : SecureFileGateway(context) {
+
+    companion object {
+        private const val MASTER_KEY_ALIAS = "super_secure_file_master_key_alias"
+        private const val MASTER_KEY_SIZE = 256
+    }
+
+    override val MASTER_KEY_ALIAS: String
+        get() = MasterKeys.getOrCreate(
+            KeyStoreHelper.buildSuperSecureMasterKeySpec(
+                context,
+                SuperSecureFileGateway.MASTER_KEY_ALIAS,
+                SuperSecureFileGateway.MASTER_KEY_SIZE
+            )
+        )
+}

--- a/app/src/main/java/com/bc/gordiansigner/service/storage/sharedpref/SecureSharedPref.kt
+++ b/app/src/main/java/com/bc/gordiansigner/service/storage/sharedpref/SecureSharedPref.kt
@@ -6,14 +6,19 @@ import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKeys
 import com.bc.gordiansigner.BuildConfig
 
-class SecureSharedPref internal constructor(context: Context) : SharedPref() {
+/**
+ * This level of security uses Android Keystore system to encrypt/decrypt the shared preference content.
+ * The key never enters to the app process so it's secure even the phone could get hack.
+ */
+class SecureSharedPref internal constructor(private val context: Context) : SharedPref() {
 
-    override val sharedPreferences: SharedPreferences = EncryptedSharedPreferences.create(
-        BuildConfig.APPLICATION_ID + "_secure",
-        MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC),
-        context,
-        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-    )
+    override val sharedPreferences: SharedPreferences
+        get() = EncryptedSharedPreferences.create(
+            BuildConfig.APPLICATION_ID + "_secure",
+            MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC),
+            context,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
 
 }

--- a/app/src/main/java/com/bc/gordiansigner/service/storage/sharedpref/SharedPref.kt
+++ b/app/src/main/java/com/bc/gordiansigner/service/storage/sharedpref/SharedPref.kt
@@ -4,6 +4,7 @@ import android.content.SharedPreferences
 import com.bc.gordiansigner.helper.ext.newGsonInstance
 import io.reactivex.Completable
 import io.reactivex.Single
+import io.reactivex.schedulers.Schedulers
 import kotlin.reflect.KClass
 
 abstract class SharedPref internal constructor() {
@@ -63,7 +64,8 @@ abstract class SharedPref internal constructor() {
     }
 }
 
-fun <T> SharedPref.rxSingle(action: (SharedPref) -> T) = Single.fromCallable { action(this) }
+fun <T> SharedPref.rxSingle(action: (SharedPref) -> T) =
+    Single.fromCallable { action(this) }.subscribeOn(Schedulers.io())
 
 fun SharedPref.rxCompletable(action: (SharedPref) -> Unit) =
-    Completable.fromCallable { action(this) }
+    Completable.fromCallable { action(this) }.subscribeOn(Schedulers.io())

--- a/app/src/main/java/com/bc/gordiansigner/service/storage/sharedpref/SharedPref.kt
+++ b/app/src/main/java/com/bc/gordiansigner/service/storage/sharedpref/SharedPref.kt
@@ -8,7 +8,7 @@ import kotlin.reflect.KClass
 
 abstract class SharedPref internal constructor() {
 
-    internal abstract val sharedPreferences: SharedPreferences
+    protected abstract val sharedPreferences: SharedPreferences
 
     @Suppress("UNCHECKED_CAST")
     fun <T : Any> get(key: String, type: KClass<T>, default: Any? = null): T {
@@ -33,6 +33,7 @@ abstract class SharedPref internal constructor() {
                 key,
                 default as? Long ?: 0
             ) as T
+            Set::class -> sharedPreferences.getStringSet(key, setOf()) as T
             else -> newGsonInstance().fromJson(
                 sharedPreferences.getString(key, ""), type.java
             )
@@ -47,6 +48,7 @@ abstract class SharedPref internal constructor() {
             is Float -> editor.putFloat(key, data as Float)
             is Int -> editor.putInt(key, data as Int)
             is Long -> editor.putLong(key, data as Long)
+            is Set<*> -> editor.putStringSet(key, data as Set<String>)
             else -> editor.putString(key, newGsonInstance().toJson(data))
         }
         editor.apply()

--- a/app/src/main/java/com/bc/gordiansigner/service/storage/sharedpref/SharedPrefApi.kt
+++ b/app/src/main/java/com/bc/gordiansigner/service/storage/sharedpref/SharedPrefApi.kt
@@ -7,17 +7,11 @@ class SharedPrefApi @Inject constructor(
     context: Context
 ) {
 
-    val STANDARD = lazy {
-        StandardSharedPref(
-            context
-        )
-    }.value
+    val STANDARD = lazy { StandardSharedPref(context) }.value
 
-    val SECURE = lazy {
-        SecureSharedPref(
-            context
-        )
-    }.value
+    val SECURE = lazy { SecureSharedPref(context) }.value
+
+    val SUPER_SECURE = lazy { SuperSecureSharedPref(context) }.value
 }
 
 

--- a/app/src/main/java/com/bc/gordiansigner/service/storage/sharedpref/SuperSecureSharedPref.kt
+++ b/app/src/main/java/com/bc/gordiansigner/service/storage/sharedpref/SuperSecureSharedPref.kt
@@ -1,0 +1,37 @@
+package com.bc.gordiansigner.service.storage.sharedpref
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKeys
+import com.bc.gordiansigner.BuildConfig
+import com.bc.gordiansigner.helper.KeyStoreHelper
+
+/**
+ * This level of security requires user authentication (device biometric) each time using the key.
+ * It also use hardware-backed if API level is 28 or above.
+ * Throws [IllegalStateException] if device biometric auth has not been setup.
+ * Throws [java.security.KeyStoreException] with root cause [android.security.keystore.UserNotAuthenticatedException] if user has not authenticated by biometric.
+ */
+class SuperSecureSharedPref internal constructor(private val context: Context) : SharedPref() {
+
+    companion object {
+        private const val MASTER_KEY_ALIAS = "super_secure_shared_pref_master_key_alias"
+        private const val MASTER_KEY_SIZE = 256
+    }
+
+    override val sharedPreferences: SharedPreferences
+        get() = EncryptedSharedPreferences.create(
+            BuildConfig.APPLICATION_ID + "_super_secure",
+            MasterKeys.getOrCreate(
+                KeyStoreHelper.buildSuperSecureMasterKeySpec(
+                    context,
+                    SuperSecureSharedPref.MASTER_KEY_ALIAS,
+                    SuperSecureSharedPref.MASTER_KEY_SIZE
+                )
+            ),
+            context,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+}


### PR DESCRIPTION
This PR does the following:
- Add new layer for storage services that require user authentication each time access storage. It also adds support for hardware-backed keystore if the device is compatible. 
- Make `SharedPreference` instance is only inside the Gateway. 