### PR TITLE
Find appropriate key for PSBT signin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "deps/libwally-core"]
 	path = deps/libwally-core
-	url = git@github.com:jollyjoker992/libwally-core.git
+	url = git@github.com:jgriffiths/libwally-core.git
+	branch = psbt_keypath

--- a/app/src/androidTest/java/com/bc/gordiansigner/model/HDKeyTest.kt
+++ b/app/src/androidTest/java/com/bc/gordiansigner/model/HDKeyTest.kt
@@ -1,10 +1,13 @@
 package com.bc.gordiansigner.model
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.bc.gordiansigner.helper.Network
 import com.blockstream.libwally.Wally
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import org.junit.runner.RunWith
 
+@RunWith(AndroidJUnit4::class)
 class HDKeyTest {
 
     private val testData = mapOf<String, Any>(
@@ -15,6 +18,12 @@ class HDKeyTest {
         "xpub" to "tpubD6NzVbkrYhZ4YcaK1UPyo5YGxLvr9s2Y1AwstREXV82YuW6tymMCSdJEyzabr4rNACTZbvJcRwmjHzfU3msWnuMqJsesmX9LivPg8pYhwxB",
         "fingerprint" to "20d25116",
         "derivePath" to "m/48h/1h/0h/2h",
+        "derivePathArray" to intArrayOf(
+            0x80000030.toInt(),
+            0x80000001.toInt(),
+            0x80000000.toInt(),
+            0x80000002.toInt()
+        ),
         "account_xprv" to "tprv8j3W3c5rkmj3bDu7q5zm4btALyJLdzHnJEiNtpsUvM3F7vtZxGF5Ts8Xe4CcBvLYQUmnhkT6pA9EnF8SW5rHSh7E8TCendMdRMSBog77wYF"
     )
 
@@ -25,7 +34,9 @@ class HDKeyTest {
         assertEquals(hdKey.xpub, testData["xpub"])
         assertEquals(hdKey.xprv, testData["xprv"])
         assertEquals(hdKey.fingerprintHex, testData["fingerprint"])
-        val accountKey = hdKey.derive(testData["derivePath"] as String)
+        var accountKey = hdKey.derive(testData["derivePath"] as String)
+        assertEquals(accountKey.xprv, testData["account_xprv"])
+        accountKey = hdKey.derive(testData["derivePathArray"] as IntArray)
         assertEquals(accountKey.xprv, testData["account_xprv"])
         assertEquals(hdKey.network, Network.TEST)
         assertEquals(Wally.hex_from_bytes(hdKey.privKey), testData["privKey"])
@@ -50,6 +61,9 @@ class HDKeyTest {
     @Test(expected = IllegalArgumentException::class)
     fun hdKeyThrowErrorFromBadSeed() {
         HDKey(ByteArray(0), Network.TEST)
+        HDKey(ByteArray(17), Network.TEST)
+        HDKey(ByteArray(32), Network.TEST)
+        HDKey(ByteArray(1), Network.TEST)
     }
 
 }

--- a/app/src/androidTest/java/com/bc/gordiansigner/model/PsbtTest.kt
+++ b/app/src/androidTest/java/com/bc/gordiansigner/model/PsbtTest.kt
@@ -1,0 +1,77 @@
+package com.bc.gordiansigner.model
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.bc.gordiansigner.helper.Network
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class PsbtTest {
+
+    private val validPsbtData = mapOf(
+        "base64_psbt" to "cHNidP8BAHQCAAAAAX0yw5njuX+bw9eWhTKamXEwEu7XBrAGHbJzo5rj3WAEAQAAAAD/////ApdXAQAAAAAAFgAUyjGTXa5ifHdGKcWaDMkgw752Y5yKAgAAAAAAABl2qRTFFybFoi59dsywV9Y0Pbh8pefv/4isAAAAAAABAH0CAAAAAUnl/XdIGG3zroFvMA+SA3CI2KlT/i6g0LiCdeXA58USAQAAAAD+////AgWyXwsAAAAAFgAUQdJWpc+3B6ZSlfPyGuk9OI8wwLdgZwEAAAAAACIAIOMp/mJo3CAgB2iF+papUxIA7IjRtRNusB+uMDUMQWZVsAwcAAEBK2BnAQAAAAAAIgAg4yn+YmjcICAHaIX6lqlTEgDsiNG1E26wH64wNQxBZlUBBUdSIQPAppUHEMAHcZMgLUbzBHxSwY049dvJEMMs52jfhliPzyEDxnEZgxNK/FRoP/ARGGzTQpxW/ObtUxKMUWRFw6f3lrdSriIGA8CmlQcQwAdxkyAtRvMEfFLBjTj128kQwyznaN+GWI/PECGCmbgAAACAAAAAgAEAAIAiBgPGcRmDE0r8VGg/8BEYbNNCnFb85u1TEoxRZEXDp/eWtwQg0lEWACICA0lSsbJjq06trZMTvw+RkM6tnsmaqHpfFkujXYvJogN0ECGCmbgAAACAAQAAgAIAAIAAAA==",
+        "signed_base64_psbt" to "cHNidP8BAHQCAAAAAX0yw5njuX+bw9eWhTKamXEwEu7XBrAGHbJzo5rj3WAEAQAAAAD/////ApdXAQAAAAAAFgAUyjGTXa5ifHdGKcWaDMkgw752Y5yKAgAAAAAAABl2qRTFFybFoi59dsywV9Y0Pbh8pefv/4isAAAAAAABAH0CAAAAAUnl/XdIGG3zroFvMA+SA3CI2KlT/i6g0LiCdeXA58USAQAAAAD+////AgWyXwsAAAAAFgAUQdJWpc+3B6ZSlfPyGuk9OI8wwLdgZwEAAAAAACIAIOMp/mJo3CAgB2iF+papUxIA7IjRtRNusB+uMDUMQWZVsAwcAAEBK2BnAQAAAAAAIgAg4yn+YmjcICAHaIX6lqlTEgDsiNG1E26wH64wNQxBZlUiAgPGcRmDE0r8VGg/8BEYbNNCnFb85u1TEoxRZEXDp/eWt0gwRQIhAKqGMDdqEJ5fzJeZ/cslYWIU9Q1X+yUR2qZH5f4OvVmqAiAV1igMVXzpRRee7lW6bA+IpXhuSemqrGhHhMVGr1BqfwEBBUdSIQPAppUHEMAHcZMgLUbzBHxSwY049dvJEMMs52jfhliPzyEDxnEZgxNK/FRoP/ARGGzTQpxW/ObtUxKMUWRFw6f3lrdSriIGA8CmlQcQwAdxkyAtRvMEfFLBjTj128kQwyznaN+GWI/PECGCmbgAAACAAAAAgAEAAIAiBgPGcRmDE0r8VGg/8BEYbNNCnFb85u1TEoxRZEXDp/eWtwQg0lEWACICA0lSsbJjq06trZMTvw+RkM6tnsmaqHpfFkujXYvJogN0ECGCmbgAAACAAQAAgAIAAIAAAA==",
+        "input_bip32_derivs" to mutableListOf(
+            Bip32Deriv(
+                "218299b8",
+                intArrayOf(0x80000000.toInt(), 0x80000000.toInt(), 0x80000001.toInt())
+            ),
+            Bip32Deriv("20d25116", intArrayOf())
+        ),
+        "recovery_phrase" to "modify tip timber tissue mandate april title unable valley spawn athlete harsh"
+    )
+
+    private val invalidBase64Psbt = arrayOf(
+        "",
+        "invalid psbt",
+        "cHNidP8BAHQCAAAAAX0yw5njuX+bw9eWhTKamXEwEu7XBrAGHbJzo5rj3WAEAQAAAAD/////ApdXAQAAAAAAFgAUyjGTXa5ifHdGKcWaDMkgw752Y5yKAgAAAAAAABl2qRTFFybFoi59dsywV9Y0Pbh8pefv/4isAAAAAAABAH0CAAAAAUnl/XdIGG3zroFvMA+SA3CI2KlT/i6g0LiCdeXA58USAQAAAAD+////AgWyXwsAAAAAFgAUQdJWpc+3B6ZSlfPyGuk9OI8wwLdgZwEAAAAAACIAIOMp/mJo3CAgB2iF+papUxIA7IjRtRNusB+uMDUMQWZVsAwcAAEBK2BnAQAAAAAAIgAg4yn+YmjcICAHaIX6lqlTEgDsiNG1E26wH64wNQxBZlUBBUdSIQPAppUHEMAHcZMgLUbzBHxSwY049dvJEMMs52jfhliPzyEDxnEZgxNK/FRoP/ARGGzTQpxW/ObtUxKMUWRFw6f3lrdSriIGA8CmlQcQwAdxkyAtRvMEfFLBjTj128kQwyznaN+GWI/PECGCmbgAAACAAAAAgAEAAIAiBgPGcRmDE0r8VGg/8BEYbNNCnFb85u1TEoxRZEXDp/eWtwQg0lEWACICA0lSsbJjq06trZMTvw+RkM6tnsmaqHpfFkujXYvJogN0ECGCmbgAAACAAQAAgAIAAIAAAA==1"
+    )
+
+    private val invalidRecoveryPhrase = arrayOf(
+        "amateur sadness dwarf gaze runway reject junk find owner advance diesel blouse",
+        "slide inherit arrow split slogan flip drip admit hover judge test convince"
+    )
+
+    @Test
+    fun testConstructValidPsbt() {
+        val psbt = Psbt(validPsbtData["base64_psbt"] as String, Network.TEST)
+        assertEquals(2, psbt.inputBip32Derivs.size)
+        val bip32Deriv0 = ((validPsbtData["input_bip32_derivs"] as List<*>)[0] as Bip32Deriv)
+        val bip32Deriv1 = ((validPsbtData["input_bip32_derivs"] as List<*>)[1] as Bip32Deriv)
+        assertEquals(bip32Deriv0, psbt.inputBip32Derivs[0])
+        assertEquals(bip32Deriv1, psbt.inputBip32Derivs[1])
+        assertTrue(psbt.signable)
+        assertEquals(validPsbtData["base64_psbt"] as String, psbt.toBase64())
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testConstructInvalidPsbt() {
+        invalidBase64Psbt.forEach {
+            Psbt(it, Network.TEST)
+        }
+    }
+
+    @Test
+    fun testSignPsbtValidKey() {
+        val psbt = Psbt(validPsbtData["base64_psbt"] as String, Network.TEST)
+        val hdKey =
+            HDKey(
+                Bip39Mnemonic(validPsbtData["recovery_phrase"] as String).seed,
+                Network.TEST
+            )
+        psbt.sign(hdKey)
+        assertEquals(validPsbtData["signed_base64_psbt"] as String, psbt.toBase64())
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testSignPsbtInvalidKey() {
+        val psbt = Psbt(validPsbtData["base64_psbt"] as String, Network.TEST)
+        invalidRecoveryPhrase.forEach {
+            val hdKey = HDKey(Bip39Mnemonic(it).seed, Network.TEST)
+            psbt.sign(hdKey)
+        }
+    }
+
+}

--- a/app/src/main/java/com/bc/gordiansigner/model/HDKey.kt
+++ b/app/src/main/java/com/bc/gordiansigner/model/HDKey.kt
@@ -49,14 +49,17 @@ class HDKey {
             .toList()
             .toIntArray()
 
-        return if (path.isNotEmpty()) HDKey(
+        return derive(path)
+    }
+
+    fun derive(path: IntArray) = if (path.isNotEmpty()) {
+        HDKey(
             bip32_key_from_parent_path(
                 rootKey,
                 path,
                 BIP32_FLAG_KEY_PRIVATE.toLong()
             ),
             network
-        ) else this
-    }
-
+        )
+    } else this
 }

--- a/app/src/main/java/com/bc/gordiansigner/model/Psbt.kt
+++ b/app/src/main/java/com/bc/gordiansigner/model/Psbt.kt
@@ -7,13 +7,62 @@ class Psbt(base64: String, val network: Network) {
 
     private val psbt: Any = psbt_from_base64(base64)
 
+    val signable = psbt_get_num_inputs(psbt) > 0 && psbt_is_finalized(psbt) == 0
+
+    val inputBip32Derivs = mutableListOf<Bip32Deriv>().apply {
+        val inputCount = psbt_get_num_inputs(psbt)
+        for (idx in 0 until inputCount) {
+            var end = false
+            var subIdx = 0
+            while (!end) {
+                try {
+                    val fingerprint = hex_from_bytes(
+                        psbt_get_input_keypath_fingerprint(
+                            psbt,
+                            idx.toLong(),
+                            subIdx.toLong()
+                        )
+                    )
+                    val path = psbt_get_input_keypath_path(psbt, idx.toLong(), subIdx.toLong())
+                    add(Bip32Deriv(fingerprint, path))
+                    subIdx++
+                } catch (e: IllegalArgumentException) {
+                    // out of range of `subIdx`
+                    end = true
+                }
+            }
+        }
+    }.toList()
+
     fun sign(privKey: ByteArray) {
+        val base64 = toBase64()
         psbt_sign(psbt, privKey, 0)
+        if (base64 == toBase64()) throw IllegalArgumentException("invalid key")
     }
 
     fun sign(hdKey: HDKey) {
-        psbt_sign(psbt, hdKey.privKey, 0)
+        sign(hdKey.privKey)
     }
 
     fun toBase64(): String = psbt_to_base64(psbt, 0)
+}
+
+data class Bip32Deriv(val fingerprintHex: String, val path: IntArray) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as Bip32Deriv
+
+        if (fingerprintHex != other.fingerprintHex) return false
+        if (!path.contentEquals(other.path)) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = fingerprintHex.hashCode()
+        result = 31 * result + path.contentHashCode()
+        return result
+    }
 }

--- a/app/src/main/java/com/bc/gordiansigner/ui/sign/PsbtSignActivity.kt
+++ b/app/src/main/java/com/bc/gordiansigner/ui/sign/PsbtSignActivity.kt
@@ -62,7 +62,7 @@ class PsbtSignActivity : BaseAppCompatActivity() {
     override fun observe() {
         super.observe()
 
-        viewModel.psbtLiveData.asLiveData().observe(this, Observer { res ->
+        viewModel.psbtSigningLiveData.asLiveData().observe(this, Observer { res ->
             when {
                 res.isSuccess() -> {
                     editText.setText(res.data())

--- a/app/src/main/java/com/bc/gordiansigner/ui/sign/PsbtSignViewModel.kt
+++ b/app/src/main/java/com/bc/gordiansigner/ui/sign/PsbtSignViewModel.kt
@@ -10,6 +10,7 @@ import com.bc.gordiansigner.service.WalletService
 import com.bc.gordiansigner.ui.BaseViewModel
 import io.reactivex.Completable
 import io.reactivex.Single
+import io.reactivex.schedulers.Schedulers
 
 class PsbtSignViewModel(
     lifecycle: Lifecycle,
@@ -18,12 +19,7 @@ class PsbtSignViewModel(
     private val rxLiveDataTransformer: RxLiveDataTransformer
 ) : BaseViewModel(lifecycle) {
 
-    companion object {
-        //Hardcoded deriv path because current can't get from psbt
-        private const val DERIV_PATH = "m"
-    }
-
-    internal val psbtLiveData = CompositeLiveData<String>()
+    internal val psbtSigningLiveData = CompositeLiveData<String>()
     internal val psbtCheckingLiveData = CompositeLiveData<Any>()
 
     fun checkPsbt(base64: String, network: Network = Network.TEST) {
@@ -35,17 +31,36 @@ class PsbtSignViewModel(
     }
 
     fun signPsbt(base64: String, network: Network) {
-        psbtLiveData.add(rxLiveDataTransformer.single(
+        psbtSigningLiveData.add(rxLiveDataTransformer.single(Single.fromCallable {
+            val psbt = Psbt(base64, network)
+            if (!psbt.signable) {
+                throw IllegalStateException("PSBT is unable to sign")
+            }
+            base64
+        }.subscribeOn(Schedulers.computation()).observeOn(Schedulers.io()).flatMap { psbtBase64 ->
+            val psbt = Psbt(psbtBase64, network)
             walletService.getLocalHDKeyXprvs().flatMap { hdKeys ->
-                if (hdKeys.isNotEmpty()) {
-                    transactionService.signPsbt(
-                        Psbt(base64, network),
-                        hdKeys.first().derive(DERIV_PATH)
-                    )
+                if (hdKeys.isEmpty()) {
+                    Single.error(IllegalStateException("HD keys is empty"))
                 } else {
-                    Single.error(Throwable("Missing account, you need to import an account first!"))
+                    val inputBip32DerivFingerprints =
+                        psbt.inputBip32Derivs.map { it.fingerprintHex }
+                    val hdKey =
+                        hdKeys.firstOrNull() { inputBip32DerivFingerprints.contains(it.fingerprintHex) }
+                    if (hdKey == null) {
+                        Single.error(IllegalStateException("No HD key is able to sign this PSBT"))
+                    } else {
+                        val path =
+                            psbt.inputBip32Derivs.first { it.fingerprintHex == hdKey.fingerprintHex }.path
+                        transactionService.signPsbt(
+                            psbt,
+                            hdKey.derive(path)
+                        )
+                    }
+
                 }
             }
+        }
         ))
     }
 

--- a/app/src/main/java/com/bc/gordiansigner/ui/sign/PsbtSignViewModel.kt
+++ b/app/src/main/java/com/bc/gordiansigner/ui/sign/PsbtSignViewModel.kt
@@ -36,9 +36,8 @@ class PsbtSignViewModel(
             if (!psbt.signable) {
                 throw IllegalStateException("PSBT is unable to sign")
             }
-            base64
-        }.subscribeOn(Schedulers.computation()).observeOn(Schedulers.io()).flatMap { psbtBase64 ->
-            val psbt = Psbt(psbtBase64, network)
+            psbt
+        }.subscribeOn(Schedulers.computation()).observeOn(Schedulers.io()).flatMap { psbt ->
             walletService.getLocalHDKeyXprvs().flatMap { hdKeys ->
                 if (hdKeys.isEmpty()) {
                     Single.error(IllegalStateException("HD keys is empty"))


### PR DESCRIPTION
This PR removes the hard code for derivation path and then using `master_fingerprint` and `path` from `bip32_derivs` to find out the appropriate key for signing PSBT. 

> Note that the reference [libwally-core PR](https://github.com/ElementsProject/libwally-core/pull/236) has not been merged. I will follow and update the submodule when it's merged. 